### PR TITLE
Update cobs dependency version

### DIFF
--- a/framed/Cargo.toml
+++ b/framed/Cargo.toml
@@ -15,7 +15,7 @@ branch = "master"
 
 [dependencies]
 byteorder = { version = "^1.2.1", default-features = false }
-cobs = { version = "^0.1.4", default-features = false }
+cobs = { version = "^0.2.3", default-features = false }
 crc16 = "^0.3.4"
 ref_slice = "^1.1.1"
 serde = { version = "^1.0", default-features = false }

--- a/framed/src/bytes.rs
+++ b/framed/src/bytes.rs
@@ -688,6 +688,15 @@ mod tests {
 
     #[test]
     #[cfg(feature = "use_std")]
+    fn decode_to_box_extra_byte_in_front() {
+        let encoded = codec().encode_to_box(&PAYLOAD).unwrap();
+        let encoded_with_extra_in_front = [&[3], &*encoded].concat();
+        let decoded = codec().decode_to_box(&encoded_with_extra_in_front);
+        assert!(decoded.is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "use_std")]
     fn decode_from_reader_ok() {
         let mut c = codec();
         let encoded = c.encode_to_box(&PAYLOAD).unwrap();


### PR DESCRIPTION
The current version of `cobs` used can panic given certain inputs. This was [fixed in cobs version 0.2.1](https://github.com/jamesmunns/cobs.rs/commit/389e17356299819109c2c6f531ad8e85b7362f81), but `framed` is still on an older version. This PR adds a test demonstrating an input that will cause `cobs` to panic on version `0.1.4` but will not panic on version `0.2.3`, and updates to the newest version of `cobs`.

Thanks for the handy library!